### PR TITLE
fix tests by locking cloneable readable to patches only

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "tmp": "0.0.33"
   },
   "dependencies": {
-    "cloneable-readable": "^1.0.0",
+    "cloneable-readable": "~1.0.0",
     "fast-json-parse": "^1.0.3",
     "minimist": "^1.2.0",
     "pino": "^4.7.0",


### PR DESCRIPTION
cloneable-readable v1.1.0+ breaks https://github.com/pinojs/pino-tee/blob/master/test/api.js#L42-L79

specifically, https://github.com/pinojs/pino-tee/blob/master/test/api.js#L66 occurs too late for cloneable-readable to hold onto the data in the pipeline so https://github.com/pinojs/pino-tee/blob/master/test/api.js#L71 is never fired and the test never finishes. 

This fixes the behaviour and tests, I found this bug using the new http://github.com/pinojs/pino-integration CI runner – this is the final thing to fix before we are sure that all tests pass in current ecosystem modules and on pino master

![image](https://user-images.githubusercontent.com/1190716/41656457-56c7b128-7490-11e8-9d17-d17c05ce7619.png)
