### PR TITLE
Allow for filtering with numeric custom levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,9 @@ a newline delimited json.
 
 The filter can be a `function` with signature `filter(line)`, where
 `line`  is a parsed JSON object. The filter can also be one of the
-[pino levels](https://github.com/pinojs/pino#loggerlevel), in that case
-_all log lines with that level or greater will be written_.
+[pino levels](https://github.com/pinojs/pino#loggerlevel) either 
+as text or as a custom level number, in that case _all log lines with 
+that level or greater will be written_.
 
 <a name="acknowledgements"></a>
 

--- a/tee.js
+++ b/tee.js
@@ -22,7 +22,10 @@ function tee (origin) {
 }
 
 function buildFilter (filter) {
-  if (typeof filter === 'string') {
+  if (typeof filter === 'number') {                                                                                                                                           
+    const num = filter                                                                                                                                                        
+    filter = function (v) { return v.level >= num }                                                                                                                           
+  } else if (typeof filter === 'string') {
     const num = pino.levels.values[filter]
 
     if (typeof num === 'number' && isFinite(num)) {

--- a/tee.js
+++ b/tee.js
@@ -22,9 +22,9 @@ function tee (origin) {
 }
 
 function buildFilter (filter) {
-  if (typeof filter === 'number') {                                                                                                                                           
-    const num = filter                                                                                                                                                        
-    filter = function (v) { return v.level >= num }                                                                                                                           
+  if (typeof filter === 'number') {
+    const num = filter
+    filter = function (v) { return v.level >= num }
   } else if (typeof filter === 'string') {
     const num = pino.levels.values[filter]
 

--- a/test/api.js
+++ b/test/api.js
@@ -179,3 +179,50 @@ test('filters data using a level name', function (t) {
 
   lines.forEach(line => origin.write(JSON.stringify(line) + '\n'))
 })
+
+test('filters data using a custon level number', function (t) {
+  t.plan(9)
+
+  const lines = [{
+    level: 30,
+    msg: 'hello world'
+  }, {
+    level: 20,
+    msg: 'a debug statement'
+  }, {
+    level: 35,
+    msg: 'a custom level log line'
+  }, {
+    level: 40,
+    msg: 'a warning'
+  }]
+
+  const lines2 = Array.from(lines)
+  const lines30 = lines.filter(x => x.level >= 30)
+  const lines35 = lines.filter(x => x.level >= 35)
+
+  const teed30 = split(JSON.parse)
+  const teed35 = split(JSON.parse)
+  const dest = split(JSON.parse)
+  const origin = new PassThrough()
+
+  const instance = tee(origin)
+
+  instance.pipe(dest)
+  instance.tee(teed30, 30)
+  instance.tee(teed35, 35)
+
+  dest.on('data', function (d) {
+    t.deepEqual(d, lines2.shift())
+  })
+
+  teed30.on('data', function (d) {
+    t.deepEqual(d, lines30.shift())
+  })
+
+  teed35.on('data', function (d) {
+    t.deepEqual(d, lines35.shift())
+  })
+
+  lines.forEach(line => origin.write(JSON.stringify(line) + '\n'))
+})


### PR DESCRIPTION
Allow for `... | pino-tee 35 35.log ...` mitigating `35` is missing in `pino.levels.values`. 
Please, consider applying and publishing.
TIA