### PR TITLE
readme: CLI example - make it more clear that pino-tee writes multiple levels.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,15 @@ npm i pino-tee -g
 
 ##### CLI
 
-The following writes the log output of `app.js` to `./all-logs`, while
-writing only warnings and errors to `./warn-log:
+Specify a minimum log level to write to file.
+
+The following writes **info**, **warn** and **error** level logs to `./info-warn-error-log`, and all output of `app.js` to `./all-logs`:
 
 ```bash
-node app.js | pino-tee warn ./warn-logs > ./all-logs
+node app.js | pino-tee info ./info-warn-error-logs | tee -a ./all-logs
 ```
+
+(using `tee -a ./all-logs` will both write to `./all-logs` and `stdout`, enabling piping of more pino transports)
 
 ##### NodeJS
 


### PR DESCRIPTION
CLI example in the README:
- make it more clear that pino-tee writes multiple levels (and not a single one)
- also use 'tee' in the example to write all logs, to allow for more pino transports

From own personal experience, I initially overlooked the fact that pino-tee writes multiple log levels to the file. Changed the readme CLI example to make it more clear.