### PR TITLE
chore: update node-tap and fix deprecation warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "pre-commit": "^1.2.2",
     "snazzy": "^9.0.0",
     "standard": "^16.0.1",
-    "tap": "^14.4.1",
+    "tap": "^16.0.1",
     "tmp": "0.2.1"
   },
   "dependencies": {

--- a/test/api.js
+++ b/test/api.js
@@ -29,11 +29,11 @@ test('tee some logs into another stream', function (t) {
   instance.tee(teed)
 
   dest.on('data', function (d) {
-    t.deepEqual(d, lines2.shift())
+    t.same(d, lines2.shift())
   })
 
   teed.on('data', function (d) {
-    t.deepEqual(d, lines3.shift())
+    t.same(d, lines3.shift())
   })
 
   lines.forEach(line => origin.write(JSON.stringify(line) + '\n'))
@@ -68,11 +68,11 @@ test('tee some logs into another stream after a while', function (t) {
   })
 
   dest.on('data', function (d) {
-    t.deepEqual(d, lines2.shift())
+    t.same(d, lines2.shift())
   })
 
   teed.on('data', function (d) {
-    t.deepEqual(d, lines3.shift())
+    t.same(d, lines3.shift())
   })
 
   lines.forEach(line => origin.write(JSON.stringify(line) + '\n'))
@@ -102,11 +102,11 @@ test('filters data', function (t) {
   instance.tee(teed, line => line.level > 30)
 
   dest.on('data', function (d) {
-    t.deepEqual(d, lines2.shift())
+    t.same(d, lines2.shift())
   })
 
   teed.on('data', function (d) {
-    t.deepEqual(d, lines3.shift())
+    t.same(d, lines3.shift())
   })
 
   lines.forEach(line => origin.write(JSON.stringify(line) + '\n'))
@@ -133,11 +133,11 @@ test('skip non-json lines', function (t) {
   instance.tee(teed)
 
   dest.on('data', function (d) {
-    t.deepEqual(d, lines2.shift())
+    t.same(d, lines2.shift())
   })
 
   teed.on('data', function (d) {
-    t.deepEqual(d, lines3.shift())
+    t.same(d, lines3.shift())
   })
 
   lines.forEach(line => origin.write(line + '\n'))
@@ -170,11 +170,11 @@ test('filters data using a level name', function (t) {
   instance.tee(teed, 'info')
 
   dest.on('data', function (d) {
-    t.deepEqual(d, lines2.shift())
+    t.same(d, lines2.shift())
   })
 
   teed.on('data', function (d) {
-    t.deepEqual(d, lines3.shift())
+    t.same(d, lines3.shift())
   })
 
   lines.forEach(line => origin.write(JSON.stringify(line) + '\n'))
@@ -226,15 +226,15 @@ test('filters data using a custon level number', function (t) {
   instance.tee(teed35, 35)
 
   dest.on('data', function (d) {
-    t.deepEqual(d, lines2.shift())
+    t.same(d, lines2.shift())
   })
 
   teed30.on('data', function (d) {
-    t.deepEqual(d, lines30.shift())
+    t.same(d, lines30.shift())
   })
 
   teed35.on('data', function (d) {
-    t.deepEqual(d, lines35.shift())
+    t.same(d, lines35.shift())
   })
 
   lines.forEach(line => origin.write(JSON.stringify(line) + '\n'))

--- a/test/bin-multiple.js
+++ b/test/bin-multiple.js
@@ -26,7 +26,7 @@ const child = childProcess.spawn(process.execPath, args, {
   detached: false
 })
 
-t.tearDown(() => {
+t.teardown(() => {
   child.stdin.end()
   child.kill()
 })
@@ -49,7 +49,7 @@ messages.forEach(line => child.stdin.write(JSON.stringify(line) + '\n'))
 child.stderr.pipe(process.stderr)
 
 child.stdout.pipe(split(JSON.parse)).on('data', function (data) {
-  t.deepEqual(data, messages.shift())
+  t.same(data, messages.shift())
   if (messages.length === 0) {
     checkFile('info', file1, expected1)
     checkFile('warn', file2, expected2)
@@ -63,7 +63,7 @@ function checkFile (level, file, expected) {
     fs.createReadStream(file.name)
       .pipe(split(JSON.parse))
       .on('data', function (data) {
-        t.deepEqual(data, expected.shift())
+        t.same(data, expected.shift())
       })
   })
 }

--- a/test/bin-stderr.js
+++ b/test/bin-stderr.js
@@ -20,7 +20,7 @@ const child = childProcess.spawn(process.execPath, args, {
   detached: false
 })
 
-t.tearDown(() => {
+t.teardown(() => {
   child.stdin.end()
   child.kill()
 })
@@ -41,12 +41,12 @@ const expected = [messages[2]]
 messages.forEach(line => child.stdin.write(JSON.stringify(line) + '\n'))
 
 child.stdout.pipe(split(JSON.parse)).on('data', function (data) {
-  t.deepEqual(data, messages.shift())
+  t.same(data, messages.shift())
 })
 
 child
   .stderr
   .pipe(split(JSON.parse))
   .on('data', function (data) {
-    t.deepEqual(data, expected.shift())
+    t.same(data, expected.shift())
   })

--- a/test/bin.js
+++ b/test/bin.js
@@ -24,7 +24,7 @@ test('invoked with correct args', (t) => {
     detached: false
   })
 
-  t.tearDown(() => {
+  t.teardown(() => {
     child.stdin.end()
     child.kill()
   })
@@ -46,7 +46,7 @@ test('invoked with correct args', (t) => {
   child.stderr.pipe(process.stderr)
 
   child.stdout.pipe(split(JSON.parse)).on('data', function (data) {
-    t.deepEqual(data, messages.shift())
+    t.same(data, messages.shift())
     if (messages.length === 0) {
       checkFile()
     }
@@ -56,7 +56,7 @@ test('invoked with correct args', (t) => {
     fs.createReadStream(file.name)
       .pipe(split(JSON.parse))
       .on('data', function (data) {
-        t.deepEqual(data, expected.shift())
+        t.same(data, expected.shift())
       })
   }
 })
@@ -85,10 +85,10 @@ test('invoked with incorrect args', (t) => {
   })
 
   child.on('close', (code) => {
-    t.deepEqual(arr, [
+    t.same(arr, [
       'pino-tee requires an even amount of args\n',
       'Usage: pino-tee [filter dest]..\n'
     ])
-    t.is(code, 1)
+    t.equal(code, 1)
   })
 })


### PR DESCRIPTION
Update node tap to latest and replace deprecated method calls with the recommended ones.

I'm updating this for an upcoming PR for issue #90 where I needed to use mocks on the tests which are only available on tap v15+. Since all tests passed without any modifications I think there's not much reason not to update it.