### PR TITLE
chore!: drop support for node 12; add support for node 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12, 14, 16]
+        node-version: [14, 16, 18]
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:


### PR DESCRIPTION
BREAKING CHANGE: Drops support for EOL node 12; adds support for node 18