### PR TITLE
refactor(transport): remove redundant guard

### DIFF
--- a/transport.js
+++ b/transport.js
@@ -10,7 +10,7 @@ const teeTransport = options => {
   return line => {
     const res = new Parse(line)
 
-    if (!res || !res.value) {
+    if (!res.value) {
       throw new Error('Failed to parse line: ', line)
     }
 


### PR DESCRIPTION
`res` is always defined by the line above:

https://github.com/pinojs/pino-tee/blob/0d2548bd485d048309b09dc7097147f53e001902/transport.js#L11

